### PR TITLE
Updates to enable tokyorust.org URL

### DIFF
--- a/infrastructure/static-site.tf
+++ b/infrastructure/static-site.tf
@@ -24,7 +24,7 @@ resource "aws_s3_bucket" "root_tokyorust" {
   }
 }
 
- resource "aws_s3_bucket_website_configuration" "example" {
+ resource "aws_s3_bucket_website_configuration" "root_tokyorust" {
   bucket = aws_s3_bucket.root_tokyorust.id
 
   redirect_all_requests_to {
@@ -32,12 +32,7 @@ resource "aws_s3_bucket" "root_tokyorust" {
   }
 }
 
-resource "aws_s3_bucket_policy" "cloudfront_access_policy" {
-  bucket = aws_s3_bucket.www_tokyorust.id
-  policy = data.aws_iam_policy_document.allow_cloudfront_read_access.json
-}
-
-data "aws_iam_policy_document" "allow_cloudfront_read_access" {
+data "aws_iam_policy_document" "www_tokyorust_allow_cloudfront_read_access" {
   version = "2012-10-17"
   statement {
     actions = [
@@ -60,10 +55,49 @@ data "aws_iam_policy_document" "allow_cloudfront_read_access" {
     condition {
       test     = "StringEquals"
       variable = "aws:SourceArn"
-      values   = [aws_cloudfront_distribution.s3_distribution.arn]
+      values   = [aws_cloudfront_distribution.www_distribution.arn]
     }
 
   }
+}
+
+data "aws_iam_policy_document" "root_tokyorust_allow_cloudfront_read_access" {
+  version = "2012-10-17"
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    effect = "Allow"
+  
+    resources = [
+      aws_s3_bucket.root_tokyorust.arn,
+      "${aws_s3_bucket.root_tokyorust.arn}/*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = [aws_cloudfront_distribution.root_distribution.arn]
+    }
+
+  }
+}
+
+resource "aws_s3_bucket_policy" "www_tokyorust_cloudfront_access_policy" {
+  bucket = aws_s3_bucket.www_tokyorust.id
+  policy = data.aws_iam_policy_document.www_tokyorust_allow_cloudfront_read_access.json
+}
+
+resource "aws_s3_bucket_policy" "root_tokyorust_cloudfront_access_policy" {
+  bucket = aws_s3_bucket.root_tokyorust.id
+  policy = data.aws_iam_policy_document.root_tokyorust_allow_cloudfront_read_access.json
 }
 
 resource "aws_cloudfront_origin_access_control" "tokyorust" {
@@ -78,7 +112,7 @@ resource "aws_cloudfront_origin_access_identity" "tokyorust" {
   comment = "Access identity for Tokyo Rust static site"
 }
 
-resource "aws_cloudfront_distribution" "s3_distribution" {
+resource "aws_cloudfront_distribution" "www_distribution" {
   origin {
     domain_name              = aws_s3_bucket.www_tokyorust.bucket_domain_name
     origin_id                = local.s3_origin_id
@@ -89,7 +123,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     # }
   }
 
-  aliases = [local.domain_name, local.host_name]
+  aliases = [local.domain_name]
 
   restrictions {
     geo_restriction {
@@ -112,6 +146,61 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     response_code = 404
     response_page_path = "/404.html"
   }
+
+  default_cache_behavior {
+    compress = true
+    viewer_protocol_policy = "redirect-to-https"
+    cached_methods = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+    allowed_methods = ["GET", "HEAD"]
+    default_ttl = 86400
+    max_ttl = 31536000
+    cache_policy_id = aws_cloudfront_cache_policy.tokyorust.id
+ }
+
+  price_class = "PriceClass_200"
+
+  tags = {
+    tokyorust = ""
+    static = ""
+  }
+}
+
+resource "aws_cloudfront_distribution" "root_distribution" {
+  origin {
+    domain_name              = aws_s3_bucket_website_configuration.root_tokyorust.website_endpoint
+    origin_id                = local.s3_origin_id
+
+    custom_origin_config {
+      origin_protocol_policy = "http-only"
+      http_port  = "80"
+      https_port = "443"
+      origin_ssl_protocols = ["TLSv1.2"]
+    }
+
+    # s3_origin_config {
+    #   origin_access_identity = aws_cloudfront_origin_access_identity.tokyorust.cloudfront_access_identity_path
+    # }
+  }
+
+  aliases = [local.host_name]
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn = local.ssl_cert_arn
+    ssl_support_method = "sni-only"
+  }
+
+  enabled = true
+  comment = "CloudFront distribution for ${local.host_name}"
+  default_root_object = "index.html"
+  http_version = "http2"
+  is_ipv6_enabled = true
 
   default_cache_behavior {
     compress = true
@@ -163,8 +252,8 @@ resource "aws_route53_record" "www_tokyorust" {
   name    = local.domain_name
   type    = "A"
   alias {
-    name = aws_cloudfront_distribution.s3_distribution.domain_name
-    zone_id = aws_cloudfront_distribution.s3_distribution.hosted_zone_id
+    name = aws_cloudfront_distribution.www_distribution.domain_name
+    zone_id = aws_cloudfront_distribution.www_distribution.hosted_zone_id
     evaluate_target_health = false
   }
 }
@@ -174,48 +263,10 @@ resource "aws_route53_record" "root_tokyorust" {
   name    = local.host_name
   type    = "A"
   alias {
-    name = aws_cloudfront_distribution.s3_distribution.domain_name
-    zone_id = aws_cloudfront_distribution.s3_distribution.hosted_zone_id
+    name = aws_cloudfront_distribution.root_distribution.domain_name
+    zone_id = aws_cloudfront_distribution.root_distribution.hosted_zone_id
     evaluate_target_health = false
   }
-}
-
-resource "aws_iam_policy" "tokyorust-static-deployer" {
-  name        = "tokyo-rust-static-deployer"
-  description = "Necessary permissions to deploy the Tokyo Rust static site"
-
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Sid = "AccessToWebsiteBuckets",
-        Effect = "Allow",
-        Action = [
-          "s3:PutBucketWebsite",
-          "s3:PutObject",
-          "s3:PutObjectAcl",
-          "s3:GetObject",
-          "s3:ListBucket",
-          "s3:DeleteObject"
-        ],
-        Resource = [
-          "${aws_s3_bucket.www_tokyorust.arn}",
-          "${aws_s3_bucket.www_tokyorust.arn}/*",
-          "${aws_s3_bucket.root_tokyorust.arn}",
-          "${aws_s3_bucket.root_tokyorust.arn}/*",
-        ]
-      },
-      {
-        Sid = "AccessToCloudfront",
-        Effect = "Allow",
-        Action = [
-          "cloudfront:GetInvalidation",
-          "cloudfront:CreateInvalidation"
-        ],
-        Resource = "*"
-      }
-    ]
-  })
 }
 
 resource "aws_iam_user" "tokyorust-static-deployer" {
@@ -226,11 +277,6 @@ resource "aws_iam_user" "tokyorust-static-deployer" {
     tokyorust = ""
     static = ""
   }
-}
-
-resource "aws_iam_user_policy_attachment" "tokyorust-static-deployer" {
-  user   = aws_iam_user.tokyorust-static-deployer.name
-  policy_arn  = aws_iam_policy.tokyorust-static-deployer.arn
 }
 
 resource "aws_s3_bucket_website_configuration" "tokyorust" {


### PR DESCRIPTION
- renamed terraform s3 bucket resource tokyo-rust www_tokyorust
- added a new s3 resource root_tokyorust configured to redirect to www.tokyorust.org
- added an A record to route53 for the root domain