### PR TITLE
fix: unfsck projects page

### DIFF
--- a/static-site/content/projects.jp.md
+++ b/static-site/content/projects.jp.md
@@ -19,7 +19,7 @@ description = "Rust wrapper for MFEM; a free, lightweight, scalable C++ library 
 name = "MORK"
 url = "https://github.com/trueagi-io/MORK/"
 logo_url = ""
-description = "MORKは、数十億規模のエンティティを効率的に扱う必要があるアプリケーション向けに設計されたデータ変換エンジンです。もともとは象徴的AIアプリケーション、特に [MeTTa言語](https://metta-lang.dev) のバックエンドとなることを目的に設計されましたが、現在ではゲノミクスから金融パターン解析まで、さまざまな分野で利用するユーザーが増えています。MORKはS式の空間を保存し、その空間内のアトムに対する単一化を提供します。また、HyperベースのHTTPサーバー経由でアクセスできるほか、ライブラリとして直接リンクして利用することも可能です。"
+description = "MORKは、数十億規模のエンティティを効率的に扱う必要があるアプリケーション向けに設計されたデータ変換エンジンです。もともとは象徴的AIアプリケーション、特に MeTTa言語 (https://metta-lang.dev) のバックエンドとなることを目的に設計されましたが、現在ではゲノミクスから金融パターン解析まで、さまざまな分野で利用するユーザーが増えています。MORKはS式の空間を保存し、その空間内のアトムに対する単一化を提供します。また、HyperベースのHTTPサーバー経由でアクセスできるほか、ライブラリとして直接リンクして利用することも可能です。"
 
 [[extra.project]]
 name = "pathmap"

--- a/static-site/content/projects.md
+++ b/static-site/content/projects.md
@@ -19,7 +19,7 @@ description = "Rust wrapper for MFEM; a free, lightweight, scalable C++ library 
 name = "MORK"
 url = "https://github.com/trueagi-io/MORK/"
 logo_url = ""
-description = "MORK is a data transformation engine designed for applications that need to work with billions of entities efficiently.  Initially designed for symbolic AI applications, to become the back for the [MeTTa language](https://metta-lang.dev), it is now used by a growing list of folks in domains from genomics to financial pattern mining.  MORK stores a space of S-Expressions and provides unification over atoms in the space.  It can be accessed via an hyper-based HTTP server, although some users have linked it directly as a library."
+description = "MORK is a data transformation engine designed for applications that need to work with billions of entities efficiently.  Initially designed for symbolic AI applications, to become the back for the MeTTa language (https://metta-lang.dev), it is now used by a growing list of folks in domains from genomics to financial pattern mining.  MORK stores a space of S-Expressions and provides unification over atoms in the space.  It can be accessed via an hyper-based HTTP server, although some users have linked it directly as a library."
 
 [[extra.project]]
 name = "pathmap"


### PR DESCRIPTION
- fix invalid string in MORK's description
- fix incorrect URL in MORK's description
- fix missing logo_url fields
- sort project list alphabetically