### PR TITLE
Add oauth2-passkey to community projects

### DIFF
--- a/static-site/content/projects.jp.md
+++ b/static-site/content/projects.jp.md
@@ -66,4 +66,10 @@ name = "Unifont-rs"
 url = "https://github.com/mkovaxx/unifont-rs"
 logo_url = ""
 description = "Unifont provides a monochrome bitmap font that covers the entire Unicode Basic Multilingual Plane. Halfwidth glyphs are 8x16, fullwidth are 16x16 pixels. Supports #[no_std] builds."
+
+[[extra.project]]
+name = "oauth2-passkey"
+url = "https://github.com/ktaka-ccmp/oauth2-passkey"
+logo_url = "https://raw.githubusercontent.com/ktaka-ccmp/oauth2-passkey/refs/heads/master/assets/o2p_logo_tight.svg"
+description = "RustウェブアプリケーションのためのOAuth2 + WebAuthn/Passkey認証ライブラリ。Google OAuth2ログイン、FIDO2パスキーの登録・認証、セッション管理、管理者UIをAxumフレームワーク統合で提供。SQLite/PostgreSQLおよびRedis/インメモリストレージバックエンドに対応。"
 +++

--- a/static-site/content/projects.jp.md
+++ b/static-site/content/projects.jp.md
@@ -38,6 +38,12 @@ logo_url = ""
 description = "MORKは、数十億規模のエンティティを効率的に扱う必要があるアプリケーション向けに設計されたデータ変換エンジンです。もともとは象徴的AIアプリケーション、特に MeTTa言語 (https://metta-lang.dev) のバックエンドとなることを目的に設計されましたが、現在ではゲノミクスから金融パターン解析まで、さまざまな分野で利用するユーザーが増えています。MORKはS式の空間を保存し、その空間内のアトムに対する単一化を提供します。また、HyperベースのHTTPサーバー経由でアクセスできるほか、ライブラリとして直接リンクして利用することも可能です。"
 
 [[extra.project]]
+name = "oauth2-passkey"
+url = "https://github.com/ktaka-ccmp/oauth2-passkey"
+logo_url = "https://raw.githubusercontent.com/ktaka-ccmp/oauth2-passkey/refs/heads/master/assets/o2p_logo_tight.svg"
+description = "RustウェブアプリケーションのためのOAuth2 + WebAuthn/Passkey認証ライブラリ。Google OAuth2ログイン、FIDO2パスキーの登録・認証、セッション管理、管理者UIをAxumフレームワーク統合で提供。SQLite/PostgreSQLおよびRedis/インメモリストレージバックエンドに対応。"
+
+[[extra.project]]
 name = "pathmap"
 url = "https://github.com/adam-Vandervorst/pathMap/"
 logo_url = ""
@@ -66,10 +72,4 @@ name = "Unifont-rs"
 url = "https://github.com/mkovaxx/unifont-rs"
 logo_url = ""
 description = "Unifont provides a monochrome bitmap font that covers the entire Unicode Basic Multilingual Plane. Halfwidth glyphs are 8x16, fullwidth are 16x16 pixels. Supports #[no_std] builds."
-
-[[extra.project]]
-name = "oauth2-passkey"
-url = "https://github.com/ktaka-ccmp/oauth2-passkey"
-logo_url = "https://raw.githubusercontent.com/ktaka-ccmp/oauth2-passkey/refs/heads/master/assets/o2p_logo_tight.svg"
-description = "RustウェブアプリケーションのためのOAuth2 + WebAuthn/Passkey認証ライブラリ。Google OAuth2ログイン、FIDO2パスキーの登録・認証、セッション管理、管理者UIをAxumフレームワーク統合で提供。SQLite/PostgreSQLおよびRedis/インメモリストレージバックエンドに対応。"
 +++

--- a/static-site/content/projects.md
+++ b/static-site/content/projects.md
@@ -66,4 +66,10 @@ name = "Unifont-rs"
 url = "https://github.com/mkovaxx/unifont-rs"
 logo_url = ""
 description = "Unifont provides a monochrome bitmap font that covers the entire Unicode Basic Multilingual Plane. Halfwidth glyphs are 8x16, fullwidth are 16x16 pixels. Supports #[no_std] builds."
+
+[[extra.project]]
+name = "oauth2-passkey"
+url = "https://github.com/ktaka-ccmp/oauth2-passkey"
+logo_url = "https://raw.githubusercontent.com/ktaka-ccmp/oauth2-passkey/refs/heads/master/assets/o2p_logo_tight.svg"
+description = "OAuth2 and WebAuthn/Passkey authentication library for Rust web applications. Provides Google OAuth2 login, FIDO2 passkey registration/authentication, session management, and admin UI with Axum framework integration. Supports SQLite/PostgreSQL and Redis/in-memory storage backends."
 +++

--- a/static-site/content/projects.md
+++ b/static-site/content/projects.md
@@ -38,6 +38,12 @@ logo_url = ""
 description = "MORK is a data transformation engine designed for applications that need to work with billions of entities efficiently.  Initially designed for symbolic AI applications, to become the back for the MeTTa language (https://metta-lang.dev), it is now used by a growing list of folks in domains from genomics to financial pattern mining.  MORK stores a space of S-Expressions and provides unification over atoms in the space.  It can be accessed via an hyper-based HTTP server, although some users have linked it directly as a library."
 
 [[extra.project]]
+name = "oauth2-passkey"
+url = "https://github.com/ktaka-ccmp/oauth2-passkey"
+logo_url = "https://raw.githubusercontent.com/ktaka-ccmp/oauth2-passkey/refs/heads/master/assets/o2p_logo_tight.svg"
+description = "OAuth2 and WebAuthn/Passkey authentication library for Rust web applications. Provides Google OAuth2 login, FIDO2 passkey registration/authentication, session management, and admin UI with Axum framework integration. Supports SQLite/PostgreSQL and Redis/in-memory storage backends."
+
+[[extra.project]]
 name = "pathmap"
 url = "https://github.com/adam-Vandervorst/pathMap/"
 logo_url = ""
@@ -66,10 +72,4 @@ name = "Unifont-rs"
 url = "https://github.com/mkovaxx/unifont-rs"
 logo_url = ""
 description = "Unifont provides a monochrome bitmap font that covers the entire Unicode Basic Multilingual Plane. Halfwidth glyphs are 8x16, fullwidth are 16x16 pixels. Supports #[no_std] builds."
-
-[[extra.project]]
-name = "oauth2-passkey"
-url = "https://github.com/ktaka-ccmp/oauth2-passkey"
-logo_url = "https://raw.githubusercontent.com/ktaka-ccmp/oauth2-passkey/refs/heads/master/assets/o2p_logo_tight.svg"
-description = "OAuth2 and WebAuthn/Passkey authentication library for Rust web applications. Provides Google OAuth2 login, FIDO2 passkey registration/authentication, session management, and admin UI with Axum framework integration. Supports SQLite/PostgreSQL and Redis/in-memory storage backends."
 +++


### PR DESCRIPTION
Hi! Thank you for maintaining the Tokyo Rust community website!

## Add oauth2-passkey to community projects

Added oauth2-passkey - an OAuth2 and WebAuthn/Passkey authentication library for Rust web applications.

- **Repository**: https://github.com/ktaka-ccmp/oauth2-passkey
- **crates.io**: https://crates.io/crates/oauth2-passkey
- Updated both `projects.md` (EN) and `projects.jp.md` (JP)

I'd love to have this project listed on the community page if possible. Thank you for reviewing!
